### PR TITLE
Update to EBS CSI Resizing behaviour

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM python:3.8-slim-buster
 
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-	# && apt-get update \
+RUN apt-get update; apt-get install curl \
+	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
 	# && apt install unzip \
 	&& unzip awscliv2.zip \
 	&& ./aws/install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 
 FROM python:3.8-slim-buster
 
-RUN apt-get update \
-	&& apt-get install curl \
+RUN apt update \
+	&& apt install curl \
 	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
 	# && apt install unzip \
 	&& unzip awscliv2.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@
 
 FROM python:3.8-slim-buster
 
-RUN apt update && apt install -y curl \
+RUN apt update && apt install -y \
+	curl \
+	unzip \
 	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-	# && apt install unzip \
 	&& unzip awscliv2.zip \
 	&& ./aws/install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 # syntax=docker/dockerfile:1
 
 FROM python:3.8-slim-buster
+
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
+	# && apt-get update \
+	# && apt install unzip \
+	&& unzip awscliv2.zip \
+	&& ./aws/install
+
 WORKDIR /app
 COPY . .
 RUN pip3 install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@
 
 FROM python:3.8-slim-buster
 
-RUN apt-get update; apt-get install curl \
+RUN apt-get update \
+	&& apt-get install curl \
 	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
 	# && apt install unzip \
 	&& unzip awscliv2.zip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 
 FROM python:3.8-slim-buster
 
-RUN apt update \
-	&& apt install curl \
+RUN apt update && apt install -y curl \
 	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
 	# && apt install unzip \
 	&& unzip awscliv2.zip \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+arrow
 couchdb
 faker
 kubernetes

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -198,7 +198,7 @@ def get_related_pod_pvc(pods: list, namespace: str):
         pvc_metadata = v1.read_namespaced_persistent_volume_claim(
             namespace=namespace, name=pvc_name)
 
-        logging.info(f'pvc_info: {pvc_metadata}')
+        # logging.info(f'pvc_info: {pvc_metadata}')
         
         # Add PVC Size
         pvc_size = pvc_metadata.status.capacity['storage']

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -237,7 +237,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         logging.info(f"vol_mods_cmd: {vol_mods_cmd}")
 
         try:
-            aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True)
+            aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True, stdout=subprocess.PIPE)
             logging.info(f"aws response: {aws_response}")
             aws_response_json = json.loads(aws_response.stdout)
             logging.info(f"aws response json: {aws_response_json}")

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -239,7 +239,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
             aws_response = subprocess.run(vol_mods_cmd.split(" "))
             logging.info(f"aws response: {aws_response}")
 
-        except Exception as e:
+        except subprocess.CalledProcessError as e:
             logging.info(e)
 
 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -248,7 +248,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
                 pass
        
             elif volume_status == "optimizing":
-                optimizing_progress = aws_response["VolumesModifications"][0]["Progress"]
+                optimizing_progress = aws_response_json["VolumesModifications"][0]["Progress"]
                 logging.info(f"volume {volume_id} is in optimizing state with progress: {optimizing_progress}")
                 continue # Go to the next item in for loop, don't resize
 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -236,7 +236,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         logging.info(f"vol_mods_cmd: {vol_mods_cmd}")
 
         try:
-            aws_response = subprocess.run(vol_mods_cmd.split(" "))
+            aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True)
             logging.info(f"aws response: {aws_response}")
 
         except subprocess.CalledProcessError as e:

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -200,6 +200,17 @@ def get_related_pod_pvc(pods: list, namespace: str):
             namespace=namespace, name=pvc_name)
 
         logging.info(f'pvc_info: {pvc_metadata}')
+
+        logging.info(f'--------------------')
+        logging.info(f'--------------------')
+        logging.info(f'--------------------')
+        logging.info(f'--------------------')
+        logging.info(f'--------------------')
+
+
+        pvc_metadata_status = v1.read_namespaced_persistent_volume_claim_status(
+            namespace=namespace, name=pvc_name)
+        logging.info(f'pvc_info: {pvc_metadata_status}')
         
         # Add PVC Size
         pvc_size = pvc_metadata.status.capacity['storage']

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -241,7 +241,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
             logging.info(f"aws response: {aws_response}")
             aws_response_json = json.loads(aws_response.stdout)
             logging.info(f"aws response json: {aws_response_json}")
-            volume_status = aws_response_json.VolumesModifications[0].ModificationState # TODO: With multiple modifications
+            volume_status = aws_response_json["VolumesModifications"][0]["ModificationState"] # TODO: With multiple modifications
             
             if volume_status == "completed":
                 logging.info(f"volume {volume_id} is completed: proceed to resize")

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -200,7 +200,7 @@ def get_related_pod_pvc(pods: list, namespace: str):
         pvc_metadata = v1.read_namespaced_persistent_volume_claim(
             namespace=namespace, name=pvc_name)
 
-        logging.info(f'pvc_info: {pvc_metadata}')
+        # logging.info(f'pvc_info: {pvc_metadata}')
         
         # Add PVC Size
         pvc_size = pvc_metadata.status.capacity['storage']

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -236,9 +236,11 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         # Get volume id
         volume_metadata = v1.read_persistent_volume(pvc[2])
 
-        logging.info(f"Persistent volume metadata: {volume_metadata}")
-        
-        vol_mods_cmd='aws ec2 describe-volumes-modifications --volume-ids {volume_id}' 
+        volume_id = volume_metadata.spec.csi.volume_handle
+
+        vol_mods_cmd=f"aws ec2 describe-volumes-modifications --volume-ids {volume_id}"
+
+        subprocess.Popen(vol_mods_cmd, shell=True, stdout = subprocess.PIPE)
 
 
         # Check status of PVC 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -234,9 +234,14 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
 
         vol_mods_cmd=f"aws ec2 describe-volumes-modifications --volume-ids {volume_id}"
         logging.info(f"vol_mods_cmd: {vol_mods_cmd}")
-        aws_response = subprocess.run(vol_mods_cmd.split(" "))
 
-        logging.info(f"aws response: {aws_response}")
+        try:
+            aws_response = subprocess.run(vol_mods_cmd.split(" "))
+            logging.info(f"aws response: {aws_response}")
+
+        except Exception as e:
+            logging.info(e)
+
 
 
         # Check status of PVC 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -234,7 +234,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
 
         vol_mods_cmd=f"aws ec2 describe-volumes-modifications --volume-ids {volume_id}"
         logging.info(f"vol_mods_cmd: {vol_mods_cmd}")
-        aws_response = subprocess.check_output(vol_mods_cmd.split(" "))
+        aws_response = subprocess.run(vol_mods_cmd.split(" "))
 
         logging.info(f"aws response: {aws_response}")
 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -227,20 +227,14 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
     
     for pod, pvc in pod_pvc_info.items():
 
-        #Previous step: Get volume name and check status from aws
-        logging.info(f"pvc info from pod {pod}: {pvc}")
-        logging.info(f"{pod}-{pvc} info:")
-        logging.info(f"pvc size:-{pvc[1]} info:")
-        logging.info(f"pvc_volume_name-{pvc[2]} info:")
-
         # Get volume id
         volume_metadata = v1.read_persistent_volume(pvc[2])
 
         volume_id = volume_metadata.spec.csi.volume_handle
 
         vol_mods_cmd=f"aws ec2 describe-volumes-modifications --volume-ids {volume_id}"
-
-        aws_response = subprocess.Popen(vol_mods_cmd, shell=True, stdout = subprocess.PIPE)
+        logging.info(f"vol_mods_cmd: {vol_mods_cmd}")
+        aws_response = subprocess.check_output(vol_mods_cmd.split(" "))
 
         logging.info(f"aws response: {aws_response}")
 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -239,7 +239,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         try:
             aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True)
             logging.info(f"aws response: {aws_response}")
-            aws_response_json = json.loads(aws_response)
+            aws_response_json = json.loads(aws_response.stdout)
             logging.info(f"aws response json: {aws_response_json}")
             volume_status = aws_response_json.VolumesModifications[0].ModificationState # TODO: With multiple modifications
             

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -240,7 +240,9 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
 
         vol_mods_cmd=f"aws ec2 describe-volumes-modifications --volume-ids {volume_id}"
 
-        subprocess.Popen(vol_mods_cmd, shell=True, stdout = subprocess.PIPE)
+        aws_response = subprocess.Popen(vol_mods_cmd, shell=True, stdout = subprocess.PIPE)
+
+        logging.info(f"aws response: {aws_response}")
 
 
         # Check status of PVC 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -1,3 +1,4 @@
+import json
 from kubernetes import client, config, watch
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream
@@ -238,7 +239,9 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         try:
             aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True)
             logging.info(f"aws response: {aws_response}")
-            volume_status = aws_response["VolumesModifications"][0]["ModificationState"] # TODO: With multiple modifications
+            aws_response_json = json.loads(aws_response)
+            logging.info(f"aws response json: {aws_response_json}")
+            volume_status = aws_response_json.VolumesModifications[0].ModificationState # TODO: With multiple modifications
             
             if volume_status == "completed":
                 logging.info(f"volume {volume_id} is completed: proceed to resize")

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -199,7 +199,7 @@ def get_related_pod_pvc(pods: list, namespace: str):
         pvc_metadata = v1.read_namespaced_persistent_volume_claim(
             namespace=namespace, name=pvc_name)
 
-        # logging.info(f'pvc_info: {pvc_metadata}')
+        logging.info(f'pvc_info: {pvc_metadata}')
         
         # Add PVC Size
         pvc_size = pvc_metadata.status.capacity['storage']
@@ -238,7 +238,7 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
 
         try:
             aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True, stdout=subprocess.PIPE)
-            logging.info(f"aws response: {aws_response}")
+            # logging.info(f"aws response: {aws_response}")
             aws_response_json = json.loads(aws_response.stdout)
             logging.info(f"aws response json: {aws_response_json}")
             volume_status = aws_response_json["VolumesModifications"][0]["ModificationState"] # TODO: With multiple modifications
@@ -253,10 +253,11 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
                 continue # Go to the next item in for loop, don't resize
 
         except subprocess.CalledProcessError as e:
-            # In case of non modified volume, continue
+            # In case of non modified volume, pass
             logging.info(e)
             pass #Continue executing resizing
         
+        logging.info(f"RESIZING PVC {pvc[0]} FROM POD {pod}")
         pvc_size = int(pvc[1].strip('Gi'))  # Must be in Gi unit
         pvc_resize_number = int(
             math.ceil(pvc_size*(resize_percentage)))  # Upper function

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -238,14 +238,14 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         try:
             aws_response = subprocess.run(vol_mods_cmd.split(" "), check=True)
             logging.info(f"aws response: {aws_response}")
-            volume_status = aws_response.VolumesModifications[0].ModificationState # TODO: With multiple modifications
+            volume_status = aws_response["VolumesModifications"][0]["ModificationState"] # TODO: With multiple modifications
             
             if volume_status == "completed":
                 logging.info(f"volume {volume_id} is completed: proceed to resize")
                 pass
        
             elif volume_status == "optimizing":
-                optimizing_progress = aws_response.VolumesModifications[0].Progress
+                optimizing_progress = aws_response["VolumesModifications"][0]["Progress"]
                 logging.info(f"volume {volume_id} is in optimizing state with progress: {optimizing_progress}")
                 continue # Go to the next item in for loop, don't resize
 

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -256,7 +256,8 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
                     logging.info(f"Last resizing time is more than 6 hours, proceed to resize again")
                     pass
                 else:
-                    raise Exception(f"We must wait for {6-diff_in_hours} hours to resize {pvc[0]}-{volume_id} again.")
+                    logging.info(f"We must wait for {6-diff_in_hours} hours to resize {pvc[0]}-{volume_id} again.")
+                    continue
        
             elif volume_status == "optimizing":
                 optimizing_progress = aws_response_json["VolumesModifications"][0]["Progress"]

--- a/src/k8s/k8s.py
+++ b/src/k8s/k8s.py
@@ -197,13 +197,9 @@ def get_related_pod_pvc(pods: list, namespace: str):
         # Get PVC Size
         pvc_metadata = v1.read_namespaced_persistent_volume_claim(
             namespace=namespace, name=pvc_name)
+
         logging.info(f'pvc_info: {pvc_metadata}')
         
-
-        pvc_metadata_status = v1.read_namespaced_persistent_volume_claim_status(
-            namespace=namespace, name=pvc_name)
-
-        logging.info(f'pvc_info STATUS: {pvc_metadata_status}')
         # Add PVC Size
         pvc_size = pvc_metadata.status.capacity['storage']
         pvc_info.append(pvc_size)
@@ -238,7 +234,10 @@ def patch_namespaced_pvc(namespace: str, pod_pvc_info: dict, resize_percentage: 
         logging.info(f"pvc_volume_name-{pvc[2]} info:")
 
         # Get volume id
+        volume_metadata = v1.read_persistent_volume(pvc[2])
 
+        logging.info(f"Persistent volume metadata: {volume_metadata}")
+        
         vol_mods_cmd='aws ec2 describe-volumes-modifications --volume-ids {volume_id}' 
 
 

--- a/src/scripts.py
+++ b/src/scripts.py
@@ -39,7 +39,7 @@ def monitor_and_scale_pvc(namespace: str, VOLUME_THRESHOLD: float, \
     logging.info(f"Pod with greater vol: {greater_pod_vol}")
     logging.info(f"% Use greater vol: {greater_vol_perc_usage}")
 
-    # Check size is over VOLUME_UMBRAL
+    # Check if size is over VOLUME_UMBRAL
     if pods_over_threshold:
         logging.info(f"Resizing PVC of pods {pods_over_threshold}")
         resize_pods_pvc(

--- a/src/scripts.py
+++ b/src/scripts.py
@@ -26,7 +26,7 @@ def monitor_and_scale_pvc(namespace: str, VOLUME_THRESHOLD: float, \
         namespace, pods, MOUNT_VOLUME_PATH
     )
 
-    # Add pods to pods_over_threshold if % usage is over (or equal) threshold
+    # Add pods to pods_over_threshold if % usage is over (or equal) to threshold
     for pod, size in pods_volumes_info.items():
         if size >= VOLUME_THRESHOLD:
             pods_over_threshold.append(pod)


### PR DESCRIPTION
# Principal Changes

- Add curl, unzip and aws-cli install on Dockerfile
- Add feature to prevent successive volume resizes within a six hours range (aws ebs restriction)
- Update behaviour on Resize. There are no longer necessary to evict the pods for resize his volume (Update on CSI driver)
- Add volume status discrimination (from aws cli) before determine volume resizing or not.